### PR TITLE
GH-23 Abort on exit (only on debug)

### DIFF
--- a/src/debugger/ECLDebugSession.ts
+++ b/src/debugger/ECLDebugSession.ts
@@ -179,9 +179,10 @@ export class ECLDebugSession extends DebugSession {
     }
 
     private disconnectWorkunit() {
-        if (this.workunit.isComplete()) {
+        if (this.workunit.isComplete() || !this.workunit.isDebugging()) {
             return Promise.resolve();
         }
+        this.sendEvent(new OutputEvent(`Aborting debug session:  ${this.workunit.Wuid}${os.EOL}`));
         return this.workunit.debugQuit().then(() => {
             return this.workunit.abort();
         }).then(() => {


### PR DESCRIPTION
On disconnect event, only abort WUs if the session was a debug session.

Fixes GH-23

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>