### PR TITLE
GH-68-ExtraLogging

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ This extension adds rich language support for the ECL language to VS Code, inclu
 The following Visual Studio Code settings are available for the ECL extension.  These can be set in user preferences (`cmd+,`) or workspace settings (`.vscode/settings.json`):
 
 ```javascript
-  // Run 'eclcc -sytnax' on save.
-  "ecl.syntaxCheckOnSave": true
-
   // Syntax check args.
   "ecl.syntaxArgs": ["-syntax"],
+
+  // Run 'eclcc -syntax' on save.
+  "ecl.syntaxCheckOnSave": true
+
+  // Run 'eclcc -syntax' on load.
+  "ecl.syntaxCheckOnLoad": true
 
 // External folders used by IMPORT
   "ecl.includeFolders": []

--- a/package.json
+++ b/package.json
@@ -337,14 +337,19 @@
                         "type": "string"
                     },
                     "default": [
-                        "-sytnax"
+                        "-syntax"
                     ],
                     "description": "eclcc syntax check arguments."
                 },
                 "ecl.syntaxCheckOnSave": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Run 'eclcc -sytnax' on save."
+                    "description": "Run 'eclcc -syntax' on save."
+                },
+                "ecl.syntaxCheckOnLoad": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Run 'eclcc -syntax' on load."
                 },
                 "ecl.includeFolders": {
                     "type": "array",

--- a/src/eclDiagnostic.ts
+++ b/src/eclDiagnostic.ts
@@ -31,7 +31,9 @@ export class ECLDiagnostic {
                     eclDiagnosticCollection.set(this._activeTextEditor, _diagnosticCache[this._activeTextEditor.toString()]);
                 } else {
                     const eclConfig = vscode.workspace.getConfiguration("ecl", event.document.uri);
-                    checkTextDocument(event.document, eclConfig);
+                    if (eclConfig.get<boolean>("syntaxCheckOnLoad")) {
+                        checkTextDocument(event.document, eclConfig);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Add extra syntax check logging.
Switching editor, should only syntax check if not checked previously.

Fixes GH-69

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>